### PR TITLE
feat: add deployment workflow for main branch

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -32,3 +32,9 @@ jobs:
     needs: build
     uses: ./.github/workflows/image.yml
     secrets: inherit
+
+  deploy:
+    if: ${{ github.ref_name == 'main' }}
+    needs: image
+    uses: ./.github/workflows/deploy.yml
+    secrets: inherit

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -1,0 +1,18 @@
+name: Deploy
+
+on:
+  workflow_call:
+
+jobs:
+  update-deployment:
+    name: Update Deployment
+    runs-on: self-hosted
+
+    steps:
+      - name: Repository Dispatch
+        uses: peter-evans/repository-dispatch@v1
+        with:
+          token: ${{ secrets.GH_PAT }}
+          repository: pesca-dev/kneipolympics-deploy
+          event-type: kneipolympics-deploy-trigger
+          client-payload: '{"ref": "${{ github.ref }}", "sha": "${{ github.sha }}"}'


### PR DESCRIPTION
Add a new deployment job to the build workflow that triggers 
only on the main branch. Create a separate deploy workflow 
that updates the deployment using a repository dispatch event. 
This change streamlines the deployment process and ensures 
that deployments occur only from the main branch.